### PR TITLE
refactor: prevent warn logs for empty directories

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -112,14 +112,15 @@ impl ScriptBuilder {
         uid: Option<u32>,
         gid: Option<u32>,
     ) -> Result<Vec<ScriptBuilder>> {
+        let mut scripts: Vec<ScriptBuilder> = Vec::new();
+
         if !path.exists() {
-            bail!("`{}` does not exist", path.display());
+            debug!("`{}` does not exist", path.display());
+            return Ok(scripts);
         }
 
         let uid = uid.unwrap_or(0); // Default is UID of root
         let gid = gid.unwrap_or(0); // Default is GID of root
-
-        let mut scripts: Vec<ScriptBuilder> = Vec::new();
 
         for entry in WalkDir::new(path)
             .min_depth(1)
@@ -171,7 +172,7 @@ impl ScriptBuilder {
         }
 
         if scripts.is_empty() {
-            bail!("No script in `{}`", path.display());
+            debug!("No script in `{}`", path.display());
         }
 
         Ok(scripts)


### PR DESCRIPTION
Changes `ScriptBuilder::build_from` to return an empty `Vec<ScriptBuilder>` if either the script directory does not exist, or no scripts are contained within that directory. This changes the previous behavior of returning an `anyhow::Error`, which would be logged as a warning by the caller. These messages are now explicitly logged as `debug!`, so that default levels of `INFO` can still log the network event itself, without also including the details of the script directories.

Closes #3.